### PR TITLE
rank: Simplify rankCheck() structure

### DIFF
--- a/src/memclicker/MemeOutputThread.java
+++ b/src/memclicker/MemeOutputThread.java
@@ -56,6 +56,8 @@ public class MemeOutputThread extends Thread {
         long c = counter.getTotalCounter()/100000;
          if (c>=0 && c<=10) {
              rank.setText(ranks[(int)c]);
+         } else if (c>10) {
+             rank.setText(ranks[10]);
          }
     }
     

--- a/src/memclicker/MemeOutputThread.java
+++ b/src/memclicker/MemeOutputThread.java
@@ -54,19 +54,9 @@ public class MemeOutputThread extends Thread {
     
     private void rankCheck(){
         long c = counter.getTotalCounter()/100000;
-        switch ((int)c){
-            case 0: rank.setText(ranks[0]); break;
-            case 1: rank.setText(ranks[1]); break;
-            case 2: rank.setText(ranks[2]); break;
-            case 3: rank.setText(ranks[3]); break;
-            case 4: rank.setText(ranks[4]); break;
-            case 5: rank.setText(ranks[5]); break;
-            case 6: rank.setText(ranks[6]); break;
-            case 7: rank.setText(ranks[7]); break;
-            case 8: rank.setText(ranks[8]); break;
-            case 9: rank.setText(ranks[9]); break;
-            case 10: rank.setText(ranks[10]); break;
-        }
+         if (c>=0 && c<=10) {
+             rank.setText(ranks[(int)c]);
+         }
     }
     
     public void stopThread(){


### PR DESCRIPTION
We don't need to use the switch statement because the c variable
will always have an integer value and we can just use it to select an
item from an array of ranks.

Signed-off-by: Pavel Dubrova pashadubrova@gmail.com